### PR TITLE
Finalize `aws_organizations_accounts` data source

### DIFF
--- a/.changelog/18589.txt
+++ b/.changelog/18589.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_organizations_accounts
+```

--- a/aws/data_source_aws_organizations_accounts.go
+++ b/aws/data_source_aws_organizations_accounts.go
@@ -38,6 +38,10 @@ func dataSourceAwsOrganizationsAccounts() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/aws/data_source_aws_organizations_accounts_test.go
+++ b/aws/data_source_aws_organizations_accounts_test.go
@@ -1,15 +1,32 @@
 package aws
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func testAccDataSourceAwsOrganizationsAccounts_basic(t *testing.T) {
+	TestAccSkip(t, "AWS Organizations Account testing is not currently automated due to manual account deletion steps.")
+
 	resourceName := "data.aws_organizations_organization.test"
 	dataSourceName := "data.aws_organizations_accounts.test1"
+
+	orgsEmailDomain, ok := os.LookupEnv("TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN")
+
+	if !ok {
+		TestAccSkip(t, "'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.")
+	}
+
+	name1 := fmt.Sprintf("tf_acctest_%d", acctest.RandInt())
+	email1 := fmt.Sprintf("tf-acctest+%d@%s", acctest.RandInt(), orgsEmailDomain)
+	name2 := fmt.Sprintf("tf_acctest_%d", acctest.RandInt())
+	email2 := fmt.Sprintf("tf-acctest+%d@%s", acctest.RandInt(), orgsEmailDomain)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -19,23 +36,23 @@ func testAccDataSourceAwsOrganizationsAccounts_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsOrganizationsAccountsConfig,
+				Config: testAccDataSourceAwsOrganizationsAccountsConfig(name1, email1, name2, email2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "children.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "non_master_accounts.0.arn", dataSourceName, "children.0.arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "non_master_accounts.0.email", dataSourceName, "children.0.email"),
 					resource.TestCheckResourceAttrPair(resourceName, "non_master_accounts.0.name", dataSourceName, "children.0.name"),
 					resource.TestCheckResourceAttrPair(resourceName, "non_master_accounts.0.id", dataSourceName, "children.0.id"),
+					resource.TestCheckResourceAttrPair(resourceName, "non_master_accounts.0.status", dataSourceName, "children.0.status"),
 				),
 			},
 		},
 	})
 }
 
-const testAccDataSourceAwsOrganizationsAccountsConfig = `
+func testAccDataSourceAwsOrganizationsAccountsConfig(name1, email1, name2, email2 string) string {
+	return fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {}
-
-data "aws_organizations_organization" "test" {}
 
 resource "aws_organizations_organizational_unit" "test" {
   name      = "test"
@@ -43,21 +60,28 @@ resource "aws_organizations_organizational_unit" "test" {
 }
 
 resource "aws_organizations_account" "test1" {
-  name  = "test_account"
-  email = "test1@example.com"
-}
+  depends_on = [aws_organizations_organization.test]
 
-data "aws_organizations_accounts" "test1" {
-  parent_id = aws_organizations_organization.test.roots[0].id
+  name      = %[1]q
+  email     = %[2]q
 }
 
 resource "aws_organizations_account" "test2" {
-  name      = "test_account_2"
-  email     = "test2@example.com"
+  name      = %[3]q
+  email     = %[4]q
   parent_id = aws_organizations_organizational_unit.test.parent_id
 }
 
+data "aws_organizations_accounts" "test1" {
+  depends_on = [aws_organizations_account.test1, aws_organizations_account.test2]
+
+  parent_id = aws_organizations_organization.test.roots[0].id
+}
+
 data "aws_organizations_accounts" "test2" {
+  depends_on = [aws_organizations_account.test1, aws_organizations_account.test2]
+
   parent_id = aws_organizations_organizational_unit.test.parent_id
 }
-`
+`, name1, email1, name2, email2)
+}

--- a/website/docs/d/organizations_accounts.html.markdown
+++ b/website/docs/d/organizations_accounts.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Organizations"
 layout: "aws"
 page_title: "AWS: aws_organizations_accounts"
 description: |-
-  Get all direct child organizational units under a parent organizational unit. This only provides immediate children, not all children.
+  Get all accounts belonging to an organizational unit.
 ---
 
 # Data Source: aws_organizations_accounts
 
-Get all direct child organizational units under a parent organizational unit. This only provides immediate children, not all children.
+Get all accounts belonging to an organizational unit.
 
 ## Example Usage
 
@@ -30,5 +30,6 @@ data "aws_organizations_accounts" "ou" {
     * `arn` - ARN of the organizational account
     * `name` - Name of the organizational account
     * `id` - ID of the organizational account
-    * `email` - `email` - Email of the account
+    * `email` - Email of the account
+    * `status` - Status of the account (either `ACTIVE` or `SUSPENDED`)
 * `id` - Parent identifier of the accounts.


### PR DESCRIPTION
Hey @ebi-yade :wave: 

I would love to see https://github.com/hashicorp/terraform-provider-aws/pull/18589 finally merged, so I figured I'd help you finalize it. I have:
- Updated the schema to include the `status` attribute
- Updated the doc and added a changelog entry
- Adjusted the test. This one is tricky because it is quite hard to delete accounts created from a test with random emails. The test code you see here ran and passed on my own AWS account, followed by manual cleanup. This is why it is `TestAccSkip`ped - actually all the other organization account tests within the provider are skipped for the same reason.
- To test this further, I built the provider binary from the branch and validated the data source works as expected in a "real" terraform configuration.

I believe the above should be sufficient to get that PR merged soon.